### PR TITLE
Skip wall points in NN inputs

### DIFF
--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -76,6 +76,7 @@ int MainCmds::runoutputtests(const vector<string>& args) {
   ScoreValue::initTables();
 
   Tests::runNNInputsV3V4Tests();
+  Tests::runWallTests();
   Tests::runNNLessSearchTests();
   Tests::runTrainingWriteTests();
   Tests::runTimeControlsTests();

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -198,7 +198,7 @@ void Board::initHash()
   rand.init("Board::initHash() for ZOBRIST_SECOND_ENCORE_START hashes");
   for(int i = 0; i<MAX_ARR_SIZE; i++) {
     for(Color j = 0; j<4; j++) {
-      if(j == C_EMPTY || j == C_WALL)
+      if(j == C_EMPTY)
         ZOBRIST_SECOND_ENCORE_START_HASH[i][j] = Hash128();
       else
         ZOBRIST_SECOND_ENCORE_START_HASH[i][j] = nextHash();

--- a/cpp/neuralnet/nninputs.cpp
+++ b/cpp/neuralnet/nninputs.cpp
@@ -856,8 +856,10 @@ static void iterLadders(const Board& board, int nnXLen, std::function<void(Loc,i
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
       Color stone = board.colors[loc];
       if(stone == P_BLACK || stone == P_WHITE) {
         int libs = board.getNumLiberties(loc);
@@ -1002,8 +1004,10 @@ void NNInputs::fillRowV3(
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
 
       //Feature 0 - on board
       setRowBin(rowBin,pos,0, 1.0f, posStride, featureStride);
@@ -1035,6 +1039,8 @@ void NNInputs::fillRowV3(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         if(hist.superKoBanned[loc] && loc != board.ko_loc) {
           int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -1047,6 +1053,8 @@ void NNInputs::fillRowV3(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.superKoBanned[loc])
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -1181,6 +1189,8 @@ void NNInputs::fillRowV3(
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
       int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
       if(area[loc] == pla)
         setRowBin(rowBin,pos,18, 1.0f, posStride, featureStride);
@@ -1194,6 +1204,8 @@ void NNInputs::fillRowV3(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.secondEncoreStartColors[loc] == pla)
           setRowBin(rowBin,pos,20, 1.0f, posStride, featureStride);
@@ -1352,8 +1364,10 @@ void NNInputs::fillRowV4(
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
 
       //Feature 0 - on board
       setRowBin(rowBin,pos,0, 1.0f, posStride, featureStride);
@@ -1385,6 +1399,8 @@ void NNInputs::fillRowV4(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         if(hist.superKoBanned[loc] && loc != board.ko_loc) {
           int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -1397,6 +1413,8 @@ void NNInputs::fillRowV4(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.superKoBanned[loc])
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -1520,6 +1538,8 @@ void NNInputs::fillRowV4(
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
       int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
       if(area[loc] == pla)
         setRowBin(rowBin,pos,18, 1.0f, posStride, featureStride);
@@ -1533,6 +1553,8 @@ void NNInputs::fillRowV4(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.secondEncoreStartColors[loc] == pla)
           setRowBin(rowBin,pos,20, 1.0f, posStride, featureStride);
@@ -1692,8 +1714,10 @@ void NNInputs::fillRowV5(
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
 
       //Feature 0 - on board
       setRowBin(rowBin,pos,0, 1.0f, posStride, featureStride);
@@ -1717,6 +1741,8 @@ void NNInputs::fillRowV5(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         if(hist.superKoBanned[loc] && loc != board.ko_loc) {
           int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
           setRowBin(rowBin,pos,3, 1.0f, posStride, featureStride);
@@ -1729,6 +1755,8 @@ void NNInputs::fillRowV5(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.superKoBanned[loc])
           setRowBin(rowBin,pos,3, 1.0f, posStride, featureStride);
@@ -1804,6 +1832,8 @@ void NNInputs::fillRowV5(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.secondEncoreStartColors[loc] == pla)
           setRowBin(rowBin,pos,11, 1.0f, posStride, featureStride);
@@ -1894,8 +1924,10 @@ void NNInputs::fillRowV6(
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
 
       //Feature 0 - on board
       setRowBin(rowBin,pos,0, 1.0f, posStride, featureStride);
@@ -1927,6 +1959,8 @@ void NNInputs::fillRowV6(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         if(hist.superKoBanned[loc] && loc != board.ko_loc) {
           int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -1939,6 +1973,8 @@ void NNInputs::fillRowV6(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.superKoBanned[loc])
           setRowBin(rowBin,pos,6, 1.0f, posStride, featureStride);
@@ -2006,6 +2042,8 @@ void NNInputs::fillRowV6(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(area[loc] == pla) {
           setRowBin(rowBin,pos,18, 1.0f, posStride, featureStride);
@@ -2163,6 +2201,8 @@ void NNInputs::fillRowV6(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.secondEncoreStartColors[loc] == pla)
           setRowBin(rowBin,pos,20, 1.0f, posStride, featureStride);
@@ -2331,8 +2371,10 @@ void NNInputs::fillRowV7(
 
   for(int y = 0; y<ySize; y++) {
     for(int x = 0; x<xSize; x++) {
-      int pos = NNPos::xyToPos(x,y,nnXLen);
       Loc loc = Location::getLoc(x,y,xSize);
+      if(board.colors[loc] == C_WALL)
+        continue;
+      int pos = NNPos::xyToPos(x,y,nnXLen);
 
       //Feature 0 - on board
       setRowBin(rowBin,pos,0, 1.0f, posStride, featureStride);
@@ -2601,6 +2643,8 @@ void NNInputs::fillRowV7(
     for(int y = 0; y<ySize; y++) {
       for(int x = 0; x<xSize; x++) {
         Loc loc = Location::getLoc(x,y,xSize);
+        if(board.colors[loc] == C_WALL)
+          continue;
         int pos = NNPos::locToPos(loc,xSize,nnXLen,nnYLen);
         if(hist.secondEncoreStartColors[loc] == pla)
           setRowBin(rowBin,pos,20, 1.0f, posStride, featureStride);

--- a/cpp/tests/testnninputs.cpp
+++ b/cpp/tests/testnninputs.cpp
@@ -5,6 +5,7 @@
 #include "../neuralnet/nninputs.h"
 #include "../neuralnet/modelversion.h"
 #include "../dataio/sgf.h"
+#include "../core/config_parser.h"
 
 using namespace std;
 using namespace TestCommon;
@@ -1494,5 +1495,25 @@ ooxooxo
       }
     }
   }
+}
+
+void Tests::runWallTests() {
+  cout << "Running wall tests" << endl;
+
+  Board board = Board(5,5);
+  Player nextPla = P_BLACK;
+  Rules rules = Rules::getTrompTaylorish();
+  BoardHistory hist(board,nextPla,rules,0);
+  Loc wallLoc = Location::getLoc(2,2,board.x_size);
+  testAssert(board.setWallFailIfOutOfBounds(wallLoc));
+
+  float rowBin[NNInputs::NUM_FEATURES_SPATIAL_V7 * 5 * 5];
+  float rowGlobal[NNInputs::NUM_FEATURES_GLOBAL_V7];
+  MiscNNInputParams nnInputParams;
+  NNInputs::fillRowV7(board,hist,nextPla,nnInputParams,5,5,false,rowBin,rowGlobal);
+  int pos = NNPos::xyToPos(2,2,5);
+  testAssert(rowBin[pos] == 0.0f);
+
+  testAssert(!hist.isLegal(board, wallLoc, nextPla));
 }
 

--- a/cpp/tests/tests.h
+++ b/cpp/tests/tests.h
@@ -38,6 +38,7 @@ namespace Tests {
 
   //testnninputs.cpp
   void runNNInputsV3V4Tests();
+  void runWallTests();
 
   //testsymmetries.cpp
   void runBasicSymmetryTests();


### PR DESCRIPTION
## Summary
- add C_WALL checks in NNInputs fillRowV* implementations
- expose a new wall test verifying holes zero features and mark moves illegal
- wire new wall test into runtests

## Testing
- `make -j$(nproc) katago`
- `./katago runoutputtests`

------
https://chatgpt.com/codex/tasks/task_e_688d270166ec8321bd655bd2ac0345af