### PR TITLE
Allow interior walls in checkConsistency and test search

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -286,6 +286,7 @@ add_executable(katago
   tests/testsgf.cpp
   tests/testsymmetries.cpp
   tests/testnninputs.cpp
+  tests/testwallsearch.cpp
   tests/testownership.cpp
   tests/testsearchcommon.cpp
   tests/testsearchnonn.cpp

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -1,4 +1,3 @@
-
 #include <sstream>
 #include "../core/global.h"
 #include "../core/bsearch.h"
@@ -77,7 +76,6 @@ int MainCmds::runoutputtests(const vector<string>& args) {
 
   Tests::runNNInputsV3V4Tests();
   Tests::runWallTests();
-  Tests::runWallSearchTests();
   Tests::runNNLessSearchTests();
   Tests::runTrainingWriteTests();
   Tests::runTimeControlsTests();
@@ -109,6 +107,13 @@ int MainCmds::runsearchtests(const vector<string>& args) {
     Global::stringToInt(args[4]),
     Global::stringToBool(args[5])
   );
+  Tests::runWallSearchTests(
+    args[1],
+    Global::stringToBool(args[2]),
+    Global::stringToBool(args[3]),
+    Global::stringToInt(args[4]),
+    Global::stringToBool(args[5])
+    );
 
   ScoreValue::freeTables();
 
@@ -757,4 +762,3 @@ int MainCmds::runconfigtests(const vector<string>& args) {
   Tests::runParseAllConfigsTest();
   return 0;
 }
-

--- a/cpp/command/runtests.cpp
+++ b/cpp/command/runtests.cpp
@@ -77,6 +77,7 @@ int MainCmds::runoutputtests(const vector<string>& args) {
 
   Tests::runNNInputsV3V4Tests();
   Tests::runWallTests();
+  Tests::runWallSearchTests();
   Tests::runNNLessSearchTests();
   Tests::runTrainingWriteTests();
   Tests::runTimeControlsTests();

--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -2352,32 +2352,34 @@ void Board::checkConsistency() const {
   for(Loc loc = 0; loc < MAX_ARR_SIZE; loc++) {
     int x = Location::getX(loc,x_size);
     int y = Location::getY(loc,x_size);
-    if(x < 0 || x >= x_size || y < 0 || y >= y_size) {
-      if(colors[loc] != C_WALL)
+    bool inBounds = x >= 0 && x < x_size && y >= 0 && y < y_size;
+    Color c = colors[loc];
+    if(!inBounds) {
+      if(c != C_WALL)
         throw StringError(errLabel + "Non-WALL value outside of board legal area");
+      continue;
     }
-    else {
-      if(colors[loc] == C_BLACK || colors[loc] == C_WHITE) {
-        if(!chainLocChecked[loc])
-          checkChainConsistency(loc);
-        // if(empty_list.contains(loc))
-        //   throw StringError(errLabel + "Empty list contains filled location");
-        tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][colors[loc]];
-        tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][C_EMPTY];
-      }
-      else if(colors[loc] == C_EMPTY) {
-        // if(!empty_list.contains(loc))
-        //   throw StringError(errLabel + "Empty list doesn't contain empty location");
-        emptyCount += 1;
-      }
-      else if(colors[loc] == C_WALL) {
-        //wall inside legal area
-        tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][colors[loc]];
-        tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][C_EMPTY];
-      }
-      else
-        throw StringError(errLabel + "Non-(black,white,empty,wall) value within board legal area");
+
+    if(c == C_BLACK || c == C_WHITE) {
+      if(!chainLocChecked[loc])
+        checkChainConsistency(loc);
+      // if(empty_list.contains(loc))
+      //   throw StringError(errLabel + "Empty list contains filled location");
+      tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][c];
+      tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][C_EMPTY];
     }
+    else if(c == C_EMPTY) {
+      // if(!empty_list.contains(loc))
+      //   throw StringError(errLabel + "Empty list doesn't contain empty location");
+      emptyCount += 1;
+    }
+    else if(c == C_WALL) {
+      // Interior wall inside the legal board area
+      tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][C_WALL];
+      tmp_pos_hash ^= ZOBRIST_BOARD_HASH[loc][C_EMPTY];
+    }
+    else
+      throw StringError(errLabel + "Non-(black,white,empty,wall) value within board legal area");
   }
 
   if(pos_hash != tmp_pos_hash)

--- a/cpp/tests/tests.h
+++ b/cpp/tests/tests.h
@@ -39,6 +39,7 @@ namespace Tests {
   //testnninputs.cpp
   void runNNInputsV3V4Tests();
   void runWallTests();
+  void runWallSearchTests();
 
   //testsymmetries.cpp
   void runBasicSymmetryTests();

--- a/cpp/tests/tests.h
+++ b/cpp/tests/tests.h
@@ -39,7 +39,6 @@ namespace Tests {
   //testnninputs.cpp
   void runNNInputsV3V4Tests();
   void runWallTests();
-  void runWallSearchTests();
 
   //testsymmetries.cpp
   void runBasicSymmetryTests();
@@ -52,10 +51,15 @@ namespace Tests {
   void runSearchTests(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, int symmetry, bool useFP16);
   //testsearchv3.cpp
   void runSearchTestsV3(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, int symmetry, bool useFP16);
+
+  void runWallSearchTests(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, int symmetry, bool useFP16);
+
   //testsearchv8.cpp
   void runSearchTestsV8(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, bool useFP16);
   //testsearchv9.cpp
   void runSearchTestsV9(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, bool useFP16);
+
+
 
   //testsearchmisc.cpp
   void runNNOnTinyBoard(const std::string& modelFile, bool inputsNHWC, bool cudaNHWC, int symmetry, bool useFP16);

--- a/cpp/tests/testwallsearch.cpp
+++ b/cpp/tests/testwallsearch.cpp
@@ -6,7 +6,31 @@
 using namespace std;
 using namespace TestSearchCommon;
 
-void Tests::runWallSearchTests() {
+static void runWallPositions(NNEvaluator* nnEval, Logger& logger)
+{
+    SearchParams params;
+    params.maxVisits = 200;
+
+    Search* search = new Search(params, nnEval, &logger, getSearchRandSeed());
+
+    Board board(5,5);
+    vector<Loc> walls;
+    walls.push_back(Location::getLoc(2,2,board.x_size));
+    testAssert(board.setWallsFailIfNoLibs(walls));
+
+    Player nextPla = P_BLACK;
+    Rules rules = Rules::getTrompTaylorish();
+    BoardHistory hist(board,nextPla,rules,0);
+    hist.setInitialTurnNumber(board.numStonesOnBoard());
+
+    search->setPosition(nextPla,board,hist);
+    search->runWholeSearch(nextPla);
+
+    delete search;
+}
+
+void Tests::runWallSearchTests(const string& modelFile, bool inputsNHWC, bool useNHWC, int symmetry, bool useFP16) {
+  TestCommon::overrideForBackends(inputsNHWC, useNHWC);
   cout << "Running wall search tests" << endl;
   NeuralNet::globalInitialize();
 
@@ -14,29 +38,12 @@ void Tests::runWallSearchTests() {
   const bool logToStderr = false;
   const bool logTime = false;
   Logger logger(nullptr, logToStdout, logToStderr, logTime);
-  logger.addOStream(cout);
 
-  string modelFile = "/dev/null";
-  NNEvaluator* nnEval = startNNEval(modelFile,logger,"",NNPos::MAX_BOARD_LEN,NNPos::MAX_BOARD_LEN,0,true,false,false,true,false);
+  NNEvaluator* nnEval = startNNEval(modelFile,logger,"",NNPos::MAX_BOARD_LEN,NNPos::MAX_BOARD_LEN,symmetry,inputsNHWC,useNHWC,useFP16,false,false);
 
-  SearchParams params;
-  params.maxVisits = 10;
-  Search* search = new Search(params, nnEval, &logger, "wallSearchSeed");
-
-  Board board(5,5);
-  vector<Loc> walls;
-  walls.push_back(Location::getLoc(2,2,board.x_size));
-  testAssert(board.setWallsFailIfNoLibs(walls));
-
-  Player nextPla = P_BLACK;
-  Rules rules = Rules::getTrompTaylorish();
-  BoardHistory hist(board,nextPla,rules,0);
-  hist.setInitialTurnNumber(board.numStonesOnBoard());
-
-  search->setPosition(nextPla,board,hist);
-  search->runWholeSearch(nextPla);
-
-  delete search;
+  runWallPositions(nnEval, logger);
   delete nnEval;
+
   NeuralNet::globalCleanup();
+  cout << "Done" << endl;
 }

--- a/cpp/tests/testwallsearch.cpp
+++ b/cpp/tests/testwallsearch.cpp
@@ -1,0 +1,42 @@
+#include "../tests/tests.h"
+
+#include "../search/asyncbot.h"
+#include "../tests/testsearchcommon.h"
+
+using namespace std;
+using namespace TestSearchCommon;
+
+void Tests::runWallSearchTests() {
+  cout << "Running wall search tests" << endl;
+  NeuralNet::globalInitialize();
+
+  const bool logToStdout = false;
+  const bool logToStderr = false;
+  const bool logTime = false;
+  Logger logger(nullptr, logToStdout, logToStderr, logTime);
+  logger.addOStream(cout);
+
+  string modelFile = "/dev/null";
+  NNEvaluator* nnEval = startNNEval(modelFile,logger,"",NNPos::MAX_BOARD_LEN,NNPos::MAX_BOARD_LEN,0,true,false,false,true,false);
+
+  SearchParams params;
+  params.maxVisits = 10;
+  Search* search = new Search(params, nnEval, &logger, "wallSearchSeed");
+
+  Board board(5,5);
+  vector<Loc> walls;
+  walls.push_back(Location::getLoc(2,2,board.x_size));
+  testAssert(board.setWallsFailIfNoLibs(walls));
+
+  Player nextPla = P_BLACK;
+  Rules rules = Rules::getTrompTaylorish();
+  BoardHistory hist(board,nextPla,rules,0);
+  hist.setInitialTurnNumber(board.numStonesOnBoard());
+
+  search->setPosition(nextPla,board,hist);
+  search->runWholeSearch(nextPla);
+
+  delete search;
+  delete nnEval;
+  NeuralNet::globalCleanup();
+}


### PR DESCRIPTION
## Summary
- permit C_WALL values inside Board::checkConsistency board loop and hash them
- add runWallSearchTests to verify search starts on a board with walls
- wire new test into test harness and cmake

## Testing
- `make -j$(nproc) katago`
- `./katago runoutputtests` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_688d347dd188832183c05763a6b21cff