### PR TITLE
Fix wall handling in territory calculations

### DIFF
--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -1847,6 +1847,8 @@ void Board::calculateArea(
     for(int y = 0; y < y_size; y++) {
       for(int x = 0; x < x_size; x++) {
         Loc loc = Location::getLoc(x,y,x_size);
+        if(colors[loc] == C_WALL)
+          continue;
         if(result[loc] == C_EMPTY)
           result[loc] = colors[loc];
       }
@@ -1872,6 +1874,8 @@ void Board::calculateIndependentLifeArea(
   for(int y = 0; y < y_size; y++) {
     for(int x = 0; x < x_size; x++) {
       Loc loc = Location::getLoc(x,y,x_size);
+      if(colors[loc] == C_WALL)
+        continue;
       if(basicArea[loc] == C_EMPTY)
         basicArea[loc] = colors[loc];
     }
@@ -1883,6 +1887,8 @@ void Board::calculateIndependentLifeArea(
     for(int y = 0; y < y_size; y++) {
       for(int x = 0; x < x_size; x++) {
         Loc loc = Location::getLoc(x,y,x_size);
+        if(colors[loc] == C_WALL)
+          continue;
         if(basicArea[loc] != C_EMPTY && basicArea[loc] != colors[loc])
           result[loc] = basicArea[loc];
       }
@@ -1892,6 +1898,8 @@ void Board::calculateIndependentLifeArea(
     for(int y = 0; y < y_size; y++) {
       for(int x = 0; x < x_size; x++) {
         Loc loc = Location::getLoc(x,y,x_size);
+        if(colors[loc] == C_WALL)
+          continue;
         if(basicArea[loc] != C_EMPTY && basicArea[loc] == colors[loc])
           result[loc] = basicArea[loc];
       }
@@ -2043,6 +2051,8 @@ void Board::calculateAreaForPla(
     for(int x = 0; x < x_size; x++) {
       Loc loc = Location::getLoc(x,y,x_size);
       if(regionIdxByLoc[loc] != -1)
+        continue;
+      if(colors[loc] == C_WALL)
         continue;
       if(colors[loc] != C_EMPTY) {
         atLeastOnePla |= (colors[loc] == pla);

--- a/cpp/game/boardhistory.cpp
+++ b/cpp/game/boardhistory.cpp
@@ -603,6 +603,8 @@ int BoardHistory::countAreaScoreWhiteMinusBlack(const Board& board, Color area[B
   for(int y = 0; y<board.y_size; y++) {
     for(int x = 0; x<board.x_size; x++) {
       Loc loc = Location::getLoc(x,y,board.x_size);
+      if(board.colors[loc] == C_WALL)
+        continue;
       if(area[loc] == C_WHITE)
         score += 1;
       else if(area[loc] == C_BLACK)
@@ -640,6 +642,8 @@ int BoardHistory::countTerritoryAreaScoreWhiteMinusBlack(const Board& board, Col
   for(int y = 0; y<board.y_size; y++) {
     for(int x = 0; x<board.x_size; x++) {
       Loc loc = Location::getLoc(x,y,board.x_size);
+      if(board.colors[loc] == C_WALL)
+        continue;
       if(area[loc] == C_WHITE)
         score += 1;
       else if(area[loc] == C_BLACK)
@@ -724,6 +728,8 @@ void BoardHistory::endGameIfAllPassAlive(const Board& board) {
   for(int y = 0; y<board.y_size; y++) {
     for(int x = 0; x<board.x_size; x++) {
       Loc loc = Location::getLoc(x,y,board.x_size);
+      if(board.colors[loc] == C_WALL)
+        continue;
       if(area[loc] == C_WHITE)
         boardScore += 1;
       else if(area[loc] == C_BLACK)

--- a/cpp/tests/testboardarea.cpp
+++ b/cpp/tests/testboardarea.cpp
@@ -152,6 +152,23 @@ XXXX.OOOO
     expect(name,out,expected);
   }
 
+  //=======================================================================
+  {
+    const char* name = "Walls treated as empty";
+    Color result[Board::MAX_ARR_SIZE];
+    Board board = Board::parseBoard(5,5,R"%%(
+.....
+..#..
+.....
+.....
+.....
+)%%");
+    board.calculateArea(result,true,true,true,false);
+    Loc center = Location::getLoc(2,2,board.x_size);
+    out << PlayerIO::colorToChar(result[center]) << endl;
+    expect(name,out,".");
+  }
+
   //============================================================================
   {
     const char* name = "Area 2";


### PR DESCRIPTION
## Summary
- skip wall points when merging areas
- ignore wall points in scoring loops
- test area calculation on boards with wall points

## Testing
- `make -C cpp -j5`
- `./cpp/katago runtests` *(fails: First line different)*

------
https://chatgpt.com/codex/tasks/task_e_688d62ede9d08321a24551b0545d8514