### PR TITLE
Guard loops against wall cells

### DIFF
--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1936,6 +1936,9 @@ std::vector<double> Search::getAverageTreeOwnership(
 
   for(int y = 0; y < board.y_size; y++) {
     for(int x = 0; x < board.x_size; x++) {
+      Loc loc = Location::getLoc(x,y,board.x_size);
+      if(!board.isOnBoard(loc))
+        continue;
       int pos = NNPos::xyToPos(x, y, nnXLen);
       Loc symLoc = SymmetryHelpers::getSymLoc(x, y, board, symmetry);
       int symPos = Location::getY(symLoc, board.x_size) * board.x_size + Location::getX(symLoc, board.x_size);
@@ -1968,6 +1971,9 @@ std::pair<std::vector<double>,std::vector<double>> Search::getAverageAndStandard
 
   for(int y = 0; y < board.y_size; y++) {
     for(int x = 0; x < board.x_size; x++) {
+      Loc loc = Location::getLoc(x,y,board.x_size);
+      if(!board.isOnBoard(loc))
+        continue;
       int pos = NNPos::xyToPos(x, y, nnXLen);
       Loc symLoc = SymmetryHelpers::getSymLoc(x, y, board, symmetry);
       int symPos = Location::getY(symLoc, board.x_size) * board.x_size + Location::getX(symLoc, board.x_size);
@@ -2170,6 +2176,11 @@ bool Search::getAnalysisJson(
       json policy = json::array();
       for(int y = 0; y < board.y_size; y++) {
         for(int x = 0; x < board.x_size; x++) {
+          Loc loc = Location::getLoc(x,y,board.x_size);
+          if(!board.isOnBoard(loc)) {
+            policy.push_back(0.0);
+            continue;
+          }
           int pos = NNPos::xyToPos(x, y, nnXLen);
           policy.push_back(Global::roundDynamic(policyProbs[pos],OUTPUT_PRECISION));
         }
@@ -2185,6 +2196,11 @@ bool Search::getAnalysisJson(
       json policy = json::array();
       for(int y = 0; y < board.y_size; y++) {
         for(int x = 0; x < board.x_size; x++) {
+          Loc loc = Location::getLoc(x,y,board.x_size);
+          if(!board.isOnBoard(loc)) {
+            policy.push_back(0.0);
+            continue;
+          }
           int pos = NNPos::xyToPos(x, y, nnXLen);
           policy.push_back(Global::roundDynamic(policyProbs[pos],OUTPUT_PRECISION));
         }

--- a/cpp/tests/testsearchnonn.cpp
+++ b/cpp/tests/testsearchnonn.cpp
@@ -641,6 +641,8 @@ xx......x
     for(int y = 0; y < board.y_size; y++) {
       for(int x = 0; x < board.x_size; x++) {
         Loc loc = Location::getLoc(x,y,board.x_size);
+        if(!board.isOnBoard(loc))
+          continue;
         if(board.colors[loc] == C_BLACK) {
           avoidMoveUntilByLoc[loc] = 0;
           board.setStone(loc,C_EMPTY);
@@ -717,6 +719,8 @@ xx......x
     for(int y = 0; y < board.y_size; y++) {
       for(int x = 0; x < board.x_size; x++) {
         Loc loc = Location::getLoc(x,y,board.x_size);
+        if(!board.isOnBoard(loc))
+          continue;
         if(board.colors[loc] == C_BLACK) {
           avoidMoveUntilByLoc[loc] = 0;
           board.setStone(loc,C_EMPTY);
@@ -793,6 +797,8 @@ xx......x
     for(int y = 0; y < board.y_size; y++) {
       for(int x = 0; x < board.x_size; x++) {
         Loc loc = Location::getLoc(x,y,board.x_size);
+        if(!board.isOnBoard(loc))
+          continue;
         if(board.colors[loc] == C_BLACK) {
           avoidMoveUntilByLoc[loc] = 0;
           board.setStone(loc,C_EMPTY);
@@ -1704,6 +1710,8 @@ oo..o..oo
       for(int y = 0; y < board.y_size; y++) {
         for(int x = 0; x < board.x_size; x++) {
           Loc loc = Location::getLoc(x,y,board.x_size);
+          if(!board.isOnBoard(loc))
+            continue;
           if(x == 0 || x == 1) {
             avoidMoveUntilByLoc[loc] = 0;
           }
@@ -1775,6 +1783,8 @@ oo..o..oo
       for(int y = 0; y < board.y_size; y++) {
         for(int x = 0; x < board.x_size; x++) {
           Loc loc = Location::getLoc(x,y,board.x_size);
+          if(!board.isOnBoard(loc))
+            continue;
           avoidMoveUntilByLoc[loc] = 3;
         }
       }
@@ -1821,6 +1831,8 @@ oo..o..oo
       for(int y = 0; y < board.y_size; y++) {
         for(int x = 0; x < board.x_size; x++) {
           Loc loc = Location::getLoc(x,y,board.x_size);
+          if(!board.isOnBoard(loc))
+            continue;
           avoidMoveUntilByLoc[loc] = 10;
         }
       }

--- a/cpp/tests/testsymmetries.cpp
+++ b/cpp/tests/testsymmetries.cpp
@@ -808,6 +808,10 @@ void Tests::runBoardSymmetryTests() {
     for(int y = 0; y < board.y_size; y++) {
       for(int x = 0; x < board.x_size; x++) {
         Loc loc = Location::getLoc(x,y,board.x_size);
+        if(!board.isOnBoard(loc)) {
+          out << '#';
+          continue;
+        }
         if(isSymDupLoc[loc])
           out << 'x';
         else


### PR DESCRIPTION
## Summary
- Skip off-board positions when reporting ownership and policy probabilities.
- Ignore wall cells during test move restrictions and symmetry output.

## Testing
- `make -j2`
- `./runsearchtestslimited.sh` *(fails: Eigen backend useNHWC = false not supported)*

------
https://chatgpt.com/codex/tasks/task_e_688d72fb59708321acc6eccb84ce16c6